### PR TITLE
feat: restore upcoming events accordion, distance levels, and hero carousel

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,14 @@
 import type { Metadata } from "next"
+import Link from "next/link"
+import { ArrowRight } from "lucide-react"
 import { siteConfig } from "@/config/site"
 import { HeroSection } from "@/components/home/hero-section"
 import { StatsSection } from "@/components/home/stats-section"
 import { ExploreCategories } from "@/components/home/explore-categories"
 import { MapSection } from "@/components/home/map-section"
 import { ResourcesSection } from "@/components/home/resources-section"
-import { FeaturedEventsSection } from "@/components/home/featured-events-section"
+import { UpcomingEventsAccordion } from "@/components/home/upcoming-events-accordion"
+import { DistanceLevels } from "@/components/home/distance-levels"
 import { HowItWorksSection } from "@/components/home/how-it-works-section"
 import { OrganizerCTA } from "@/components/cta/organizer-cta"
 import { NewsletterSection } from "@/components/home/newsletter-section"
@@ -174,16 +177,39 @@ export default async function IndexPage() {
       {/* 5. Resources */}
       <ResourcesSection />
 
-      {/* 6. Featured Events */}
-      <FeaturedEventsSection events={upcomingEvents} />
+      {/* 6. Distance Levels */}
+      <DistanceLevels events={upcomingEvents} />
 
-      {/* 7. How It Works */}
+      {/* 7. Upcoming Events */}
+      <section className="container py-20 md:py-28">
+        <div className="mb-12 flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-end">
+          <div>
+            <span className="mb-3 inline-block rounded-full bg-primary/10 px-4 py-1.5 text-sm font-medium text-primary">
+              No te lo pierdas
+            </span>
+            <h2 className="text-3xl font-extrabold tracking-tight md:text-5xl">Próximos Eventos</h2>
+            <p className="mt-3 text-lg text-muted-foreground">
+              Las carreras más emocionantes que se acercan en Colombia
+            </p>
+          </div>
+          <Link
+            href="/events"
+            className="group inline-flex items-center justify-center gap-2 rounded-full border border-input bg-background px-8 py-2.5 text-sm font-medium shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+          >
+            Ver todos
+            <ArrowRight className="ml-2 size-4 transition-transform group-hover:translate-x-1" />
+          </Link>
+        </div>
+        <UpcomingEventsAccordion events={upcomingEvents} />
+      </section>
+
+      {/* 8. How It Works */}
       <HowItWorksSection />
 
-      {/* 8. Organizer CTA */}
+      {/* 9. Organizer CTA */}
       <OrganizerCTA />
 
-      {/* 9. Newsletter */}
+      {/* 10. Newsletter */}
       <NewsletterSection />
     </>
   )

--- a/components/home/hero-banner.tsx
+++ b/components/home/hero-banner.tsx
@@ -1,15 +1,15 @@
 "use client"
 
-import React from "react"
+import React, { useState, useEffect, useCallback } from "react"
 import Image from "next/image"
-import { motion, type Variants } from "framer-motion"
+import { motion, AnimatePresence, type Variants } from "framer-motion"
 import { cn } from "@/lib/utils"
 
 export interface HeroBannerProps {
   title: string
   subtitle: string
   label?: string
-  image: string
+  images: string[]
   actions?: React.ReactNode
   stats?: { value: string; label: string }[]
   className?: string
@@ -63,11 +63,23 @@ export function HeroBanner({
   title,
   subtitle,
   label,
-  image,
+  images,
   actions,
   stats,
   className,
 }: HeroBannerProps) {
+  const [currentIndex, setCurrentIndex] = useState(0)
+
+  const nextImage = useCallback(() => {
+    setCurrentIndex((prev) => (prev + 1) % images.length)
+  }, [images.length])
+
+  useEffect(() => {
+    if (images.length <= 1) return
+    const interval = setInterval(nextImage, 6000)
+    return () => clearInterval(interval)
+  }, [images.length, nextImage])
+
   return (
     <section
       className={cn(
@@ -75,16 +87,27 @@ export function HeroBanner({
         className
       )}
     >
-      {/* Background image — 21:9 crop via object-cover */}
+      {/* Background images carousel */}
       <div className="absolute inset-0 z-0">
-        <Image
-          src={image}
-          alt={title}
-          fill
-          priority
-          sizes="100vw"
-          className="object-cover object-center"
-        />
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={currentIndex}
+            className="absolute inset-0"
+            initial={{ opacity: 0, scale: 1.1 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 1.2, ease: "easeInOut" }}
+          >
+            <Image
+              src={images[currentIndex]}
+              alt={title}
+              fill
+              priority
+              sizes="100vw"
+              className="object-cover object-center"
+            />
+          </motion.div>
+        </AnimatePresence>
       </div>
 
       {/* Overlay: light 35% near top, dark 60% from bottom */}
@@ -179,6 +202,25 @@ export function HeroBanner({
           <div className="hidden lg:col-span-5 lg:block xl:col-span-6" />
         </motion.div>
       </div>
+
+      {/* Carousel navigation dots */}
+      {images.length > 1 && (
+        <div className="absolute bottom-24 left-1/2 z-10 flex -translate-x-1/2 gap-2">
+          {images.map((_, index) => (
+            <button
+              key={index}
+              onClick={() => setCurrentIndex(index)}
+              className={cn(
+                "h-2 rounded-full transition-all duration-500",
+                index === currentIndex
+                  ? "w-8 bg-white"
+                  : "w-2 bg-white/40 hover:bg-white/60"
+              )}
+              aria-label={`Ir a imagen ${index + 1}`}
+            />
+          ))}
+        </div>
+      )}
 
       {/* Scroll indicator */}
       <motion.div

--- a/components/home/hero-banner.tsx
+++ b/components/home/hero-banner.tsx
@@ -71,6 +71,7 @@ export function HeroBanner({
   const [currentIndex, setCurrentIndex] = useState(0)
 
   const nextImage = useCallback(() => {
+    if (images.length === 0) return
     setCurrentIndex((prev) => (prev + 1) % images.length)
   }, [images.length])
 
@@ -88,27 +89,29 @@ export function HeroBanner({
       )}
     >
       {/* Background images carousel */}
-      <div className="absolute inset-0 z-0">
-        <AnimatePresence mode="wait">
-          <motion.div
-            key={currentIndex}
-            className="absolute inset-0"
-            initial={{ opacity: 0, scale: 1.1 }}
-            animate={{ opacity: 1, scale: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 1.2, ease: "easeInOut" }}
-          >
-            <Image
-              src={images[currentIndex]}
-              alt={title}
-              fill
-              priority
-              sizes="100vw"
-              className="object-cover object-center"
-            />
-          </motion.div>
-        </AnimatePresence>
-      </div>
+      {images.length > 0 && (
+        <div className="absolute inset-0 z-0">
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={currentIndex}
+              className="absolute inset-0"
+              initial={{ opacity: 0, scale: 1.1 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 1.2, ease: "easeInOut" }}
+            >
+              <Image
+                src={images[Math.min(currentIndex, images.length - 1)]}
+                alt={title}
+                fill
+                priority
+                sizes="100vw"
+                className="object-cover object-center"
+              />
+            </motion.div>
+          </AnimatePresence>
+        </div>
+      )}
 
       {/* Overlay: light 35% near top, dark 60% from bottom */}
       <div
@@ -209,6 +212,7 @@ export function HeroBanner({
           {images.map((_, index) => (
             <button
               key={index}
+              type="button"
               onClick={() => setCurrentIndex(index)}
               className={cn(
                 "h-2 rounded-full transition-all duration-500",

--- a/components/home/hero-section.tsx
+++ b/components/home/hero-section.tsx
@@ -8,8 +8,8 @@ import { ArrowRight, MapPin } from "lucide-react"
 export interface HeroSectionProps {
   eventsCount: number
   departmentsCount: number
-  /** Override the hero image path. Falls back to gradient if not found. */
-  heroImage?: string
+  /** Override the hero images. Falls back to gradient if not found. */
+  heroImages?: string[]
 }
 
 /**
@@ -19,7 +19,7 @@ export interface HeroSectionProps {
 export function HeroSection({
   eventsCount,
   departmentsCount,
-  heroImage = "/images/hero/hero-home.jpg",
+  heroImages = ["/images/hero/hero-home.jpg", "/images/home/hero-trail-running.jpg"],
 }: HeroSectionProps) {
   return (
     <HeroBanner
@@ -30,7 +30,7 @@ export function HeroSection({
           ? `${eventsCount} eventos activos`
           : "La plataforma de atletismo"
       } en Colombia`}
-      image={heroImage}
+      images={heroImages}
       actions={
         <>
           <Button

--- a/components/home/hero-section.tsx
+++ b/components/home/hero-section.tsx
@@ -8,7 +8,7 @@ import { ArrowRight, MapPin } from "lucide-react"
 export interface HeroSectionProps {
   eventsCount: number
   departmentsCount: number
-  /** Override the hero images. Falls back to gradient if not found. */
+  /** Override the hero carousel images. Defaults to hero-home and hero-trail-running. */
   heroImages?: string[]
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "embla-carousel-react": "^8.6.0",
         "firebase": "^12.0.0",
         "firebase-admin": "^13.4.0",
-        "framer-motion": "^12.42.0",
+        "framer-motion": "^12.42.2",
         "gray-matter": "^4.0.3",
         "groq-sdk": "^0.29.0",
         "leaflet": "^1.9.4",
@@ -8446,12 +8446,12 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.42.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.0.tgz",
-      "integrity": "sha512-wp7EJnfWaaEScVygKv3e20udoRz+LbtxScsuTkakAxfXmt+ReC6WyPW2nINRAGvd+hG9odwcjBLyOTPjH5pBRA==",
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.2.tgz",
+      "integrity": "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.42.0",
+        "motion-dom": "^12.42.2",
         "motion-utils": "^12.39.0",
         "tslib": "^2.4.0"
       },
@@ -11065,9 +11065,9 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.42.0",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.0.tgz",
-      "integrity": "sha512-M63h4n8R+quJdNhBwuLlgxM+OLYa9+I/T2pzDRboB9fLXRdbou+Gw7Zury+SkpaCyACP1JHSjHgZ1EgTkBr30w==",
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.2.tgz",
+      "integrity": "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==",
       "license": "MIT",
       "dependencies": {
         "motion-utils": "^12.39.0"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "embla-carousel-react": "^8.6.0",
     "firebase": "^12.0.0",
     "firebase-admin": "^13.4.0",
-    "framer-motion": "^12.42.0",
+    "framer-motion": "^12.42.2",
     "gray-matter": "^4.0.3",
     "groq-sdk": "^0.29.0",
     "leaflet": "^1.9.4",


### PR DESCRIPTION
## Cambios

### Próximos Eventos
- Reemplazado `FeaturedEventsSection` por `UpcomingEventsAccordion` (bento grid con imágenes expandibles, recuperado del commit `724cdb6`)

### Elige tu desafío
- Agregado `DistanceLevels` de vuelta al home (secciones 5K, 10K, 21K, 42K con imágenes y conteo)

### Hero carrusel
- `HeroBanner` ahora rota entre `hero-home.jpg` y `hero-trail-running.jpg` cada 6s con fade transition
- Dots de navegación para cambiar manualmente

### Preview
https://aldebaran-avifasrt4-luismateohs-projects.vercel.app